### PR TITLE
Rework for middleware handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /node_modules
 /npm-debug.log*
+.idea

--- a/src/Response.js
+++ b/src/Response.js
@@ -38,7 +38,6 @@ class Response {
     if (typeof body !== 'string') {
       this.body = JSON.stringify(body);
     }
-    this.end();
     return this;
   }
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,34 +1,40 @@
 const Request = require('./Request');
 const Response = require('./Response');
 
-module.exports = logger => {
-  const middlewares = [];
-  return {
-    use: (middleware) => {
-      middlewares.push(middleware);
-    },
-    function: (name, controller) => async (event, context) => {
-      const req = new Request(event);
-      logger.debug(`Request for '${name}' with headers '${JSON.stringify(req.headers)}' and body '${JSON.stringify(req.body)}'`);
-      const res = new Response(context);
-      try {
-        middlewares.forEach(async (middleware) => {
-          await new Promise((resolve, reject) => {
-            middleware(req, res, (err) => {
-              if (err) {
-                reject(err);
-              } else {
-                resolve();
-              }
-            });
-          });
-        });
-        await controller(req, res);
-      } catch (e) {
-        logger.warn(`Error: ${e.message}`);
-        res.status(400).send(e.message);
-      }
-      logger.debug(`Response for '${name}' with statusCode '${res.statusCode}', headers '${JSON.stringify(res.headers)}' and body '${JSON.stringify(res.body)}'`);
+const stack = [];
+const use = middleware => stack.push(middleware);
+
+const handle = (name, controller) => async (event, context) => {
+  const req = new Request(event);
+  const res = new Response(context);
+
+  // A controller is also a middleware
+  const stackWithController = stack;
+  // stackWithController.push(async (req, res, next) => await controller(req, res));
+
+  // Index for the current middleware
+  let idx = -1;
+
+  await next();
+  async function next(error) {
+    if (error) {
+      return res.status(400).send(error);
     }
-  };
+
+    idx++;
+    if (idx >= stackWithController.length) {
+      // We are done, work from inner to outer again
+      return;
+    }
+
+    await stackWithController[idx](req, res, next);
+  }
+
+  // We need to call a end() again otherwise the response fail's
+  res.end();
+};
+
+module.exports = {
+  use,
+  handle
 };


### PR DESCRIPTION
The next() function from express isn't just a simple promise, it's keeping track of a stack enabling a layered system. With this patch a middleware like this becomes possible (like the express.js):

```javascript
async (req, res, next) => {
    // Do something on our way in
    next()
    // Do something else on our way out
}
```