### PR TITLE
Rename method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ const lambda = require('mxd-lambda')(logger);
 lambda.use(require('mxd-cors')());
 
 module.exports = {
-  example: lambda.function('example', (req, res) => {
+  example: lambda.handle('example', (req, res) => {
     res.send();
   }),
 };


### PR DESCRIPTION
This should be handle instead of function. Shouldn't it?